### PR TITLE
BBMASK typo fix

### DIFF
--- a/conf/machine/include/amdx86-baldeagle.inc
+++ b/conf/machine/include/amdx86-baldeagle.inc
@@ -29,6 +29,6 @@ DISTRO_FEATURES_remove="alsa pulseaudio"
 # Mask out recipes for packages we do not support for
 # amdx86 but may be required by others. Use '|' sign
 # between the patterns.
-BBMASK = "\
+BBMASK += "\
 .*/meta-amd/common/recipes-support/libtinyxml\
 "


### PR DESCRIPTION
Hi Peter,
Hope you are doing well. 
A typo was found in the meta-baldeagle repo that was causing some issues with losing the BBMASK from other layers. Would it be possible to merge this?
Thanks,
Greg LaMarre
